### PR TITLE
Add JSON paste import to designer

### DIFF
--- a/src/LangGraphFlowDesigner.jsx
+++ b/src/LangGraphFlowDesigner.jsx
@@ -1684,7 +1684,7 @@ const LangGraphFlowDesigner = () => {
                   setJsonImportError('')
                   setJsonImportSuccess('')
                 }}
-                placeholder="Paste the JSON exported from LangGraph Flow Designer or the LangGraph API"
+                placeholder="Paste JSON workflow configuration from external tools or editors"
                 className="w-full h-32 p-2 text-xs font-mono border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
               {jsonImportError && (


### PR DESCRIPTION
## Summary
- add editor to the JSON viewer that lets users paste or load JSON for importing into the graph
- provide load-current helper and success or error feedback for pasted JSON imports

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce57a915a4832bba750a2f447612af